### PR TITLE
LUT-26872: Remove trailing commas from public address in Solr meeting parsing

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/modules/rest/service/AppointmentMeetingPointsService.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/modules/rest/service/AppointmentMeetingPointsService.java
@@ -139,7 +139,13 @@ public class AppointmentMeetingPointsService
                 Matcher matcher = ZIP_CITY_PATTERN.matcher( solrMeeting.getAddressText( ) );
                 if ( matcher.find( ) )
                 {
-                    meeting.setPublicAdress( matcher.group( 1 ).trim( ) );
+                    String publicAddress = matcher.group(1).trim();
+
+                    while (publicAddress.endsWith(","))
+                    {
+                        publicAddress = publicAddress.substring(0, publicAddress.length() - 1).trim();
+                    }
+                    meeting.setPublicAdress( publicAddress );
                     meeting.setZipCode( matcher.group( 2 ) );
                     meeting.setCityName( matcher.group( 3 ).trim( ) );
                 }


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/26872